### PR TITLE
Add k8s tester script

### DIFF
--- a/utils/chapter_k8s.sh
+++ b/utils/chapter_k8s.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+[[ $1 != chapter??/provision/kubernetes*/README.md ]] && exit 1
+[[ ! -f $1 ]] && exit 1
+
+cd $(dirname $1)
+bash <(awk '/^```bash$/ {code=1; getline} /^```$/ {code=0} code; /deployment\/prometheus-operator/ {print "sleep 30"}' README.md)


### PR DESCRIPTION
This script runs the code blocks in the README.md that is inside the
kubernetes provisioning directories.

Additionally, it injects a delay of 30 seconds between deploying the
prometheus operator and deploying other resources dependent of it.