### PR TITLE
chapter06: Fix install directive

### DIFF
--- a/chapter06/provision/blackbox_exporter.sh
+++ b/chapter06/provision/blackbox_exporter.sh
@@ -18,7 +18,7 @@ fi
 
 tar zxf "${CACHE_PATH}/${ARCHIVE}" -C /usr/bin --strip-components=1 --wildcards */blackbox_exporter
 
-install -d 0755 -o blackbox_exporter -g blackbox_exporter /etc/blackbox_exporter/
+install -d -m 0755 -o blackbox_exporter -g blackbox_exporter /etc/blackbox_exporter/
 install -m 0644 -D /vagrant/chapter06/configs/blackbox_exporter/blackbox.yml /etc/blackbox_exporter/blackbox.yml
 install -m 0644 /vagrant/chapter06/configs/blackbox_exporter/blackbox-exporter.service /etc/systemd/system/
 # ICMP probe requires access to raw sockets

--- a/chapter06/provision/grok_exporter.sh
+++ b/chapter06/provision/grok_exporter.sh
@@ -21,7 +21,7 @@ fi
 TMPD=$(mktemp -d)
 unzip -x "${CACHE_PATH}/${ARCHIVE}" -d "$TMPD"
 
-install -d 0755 -o grok_exporter -g grok_exporter /etc/grok_exporter/
+install -d -m 0755 -o grok_exporter -g grok_exporter /etc/grok_exporter/
 install -m 0644 -D -t /etc/grok_exporter/patterns $TMPD/grok_exporter-${GROK_EXPORTER_VERSION}.linux-amd64/patterns/*
 install -m 0755 $TMPD/grok_exporter-${GROK_EXPORTER_VERSION}.linux-amd64/grok_exporter /usr/bin/
 install -m 0644 -D /vagrant/chapter06/configs/grok_exporter/config.yml /etc/grok_exporter/

--- a/chapter06/provision/mtail_exporter.sh
+++ b/chapter06/provision/mtail_exporter.sh
@@ -17,7 +17,7 @@ if ! id mtail_exporter > /dev/null 2>&1 ; then
 fi
 
 install -m 0755 ${CACHE_PATH}/${ARCHIVE} /usr/bin/mtail
-install -d 0755 -o mtail_exporter -g mtail_exporter /etc/mtail_exporter/
+install -d -m 0755 -o mtail_exporter -g mtail_exporter /etc/mtail_exporter/
 install -m 0644 -D /vagrant/chapter06/configs/mtail_exporter/line_count.mtail /etc/mtail_exporter/
 install -m 0644 /vagrant/chapter06/configs/mtail_exporter/mtail-exporter.service /etc/systemd/system/
 


### PR DESCRIPTION
The install directive was wrongly configured which was causing a new dir
to be created in the cache path.