### PR TITLE
Try to install requirement if not present

### DIFF
--- a/utils/helpers.sh
+++ b/utils/helpers.sh
@@ -1,3 +1,5 @@
+# vi: set ts=2 sw=2 :
+
 CACHE_PATH="/vagrant/cache"
 
 err() {
@@ -50,8 +52,18 @@ check_requirements() {
     if hash "${r}" > /dev/null 2>&1; then
       continue
     else
-      err "Software requirement \"${r}\" is not available"
-      return 1
+      if try_install "${r}" > /dev/null ; then
+        continue
+      else
+        err "Software requirement \"${r}\" is not available"
+        return 1
+      fi
     fi
   done
+}
+
+try_install() {
+  export DEBIAN_FRONTEND=noninteractive
+  apt-get update
+  apt-get install -y "$1"
 }


### PR DESCRIPTION
Latest version of our default Linux distribution (Ubuntu-18.04) shopped shipping `curl` in it's base install, which breaks our provisioners.

Fixes #41